### PR TITLE
Make templates compatible with jinja2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ What you need to know:
 
 0. Add 'django_cape' to your `INSTALLED_APPS`, and extend `cape/shell.html`.
 
-1. Set up Javascript variables in `javascript-variables`.
+1. Set up Javascript variables in `javascript_variables`.
 
-2. Pull in libraries in `javascript-libraries`.
+2. Pull in libraries in `javascript_libraries`.
 
-3. Apply progressive enhancement in `javascript-enhance`.
+3. Apply progressive enhancement in `javascript_enhance`.
 
-4. Asynchronous code, analytics and further behavioural changes (eg form submission) will generally go in `javascript-asynchronous`.
+4. Asynchronous code, analytics and further behavioural changes (eg form submission) will generally go in `javascript_asynchronous`.
 
-5. If your primary language is not British English, override `html-lang`.
+5. If your primary language is not British English, override `html_lang`.
 
-6. If you need to add attributes to the `<html>` element, put them in `html-attributes`.
+6. If you need to add attributes to the `<html>` element, put them in `html_attributes`.
 
-7. Add your normal page content in `body-sheath`.
+7. Add your normal page content in `body_sheath`.
 
-8. If you use analytics, put them in `javascript-analytics`.
+8. If you use analytics, put them in `javascript_analytics`.
 
-9. If you **really** need to put some JavaScript in the `<head>` (eg for measuring page timing) put it in `javascript-head`.
+9. If you **really** need to put some JavaScript in the `<head>` (eg for measuring page timing) put it in `javascript_head`.
 
 When everything runs smoothly, the CSS flow is as follows:
 
@@ -43,18 +43,18 @@ Generally you use `.js-capable` to hide stuff, `.js-timeout` to show it again, a
 Although CAPE is primarily about better progressive enhancement, we also provide a template with recommended slots for the `<head>` of your pages, which
 you use by extending `cape/base.html` instead of `cape/shell.html`. It contains the following blocks:
 
-* `head-title-website`: name of the website
-* `head-title-page`: title of the page
-* `head-title`: override if you need more control over the `<title>` tag
-* `head-html5shim`: included by default, override if you don't want it
-* `head-viewport`: set to `device-width` with a scale of 1 by default, override if you hate mobile users
-* `head-meta`: where to put any other `<meta>` tags
-* `head-icons`: where to declare your favicons and Apple touch icons
-* `head-links`: where to put `<link>` tags, such as `rel=canonical`
-* `head-alternate`: where to put your Atom feeds
-* `head-css-stylesheet`: where to put the `<link>` to your stylesheet
-* `head-css-localstyles`: where to put page-specific CSS links or blocks
-* `head-css`: override if you need more control over styles
+* `head_title_website`: name of the website
+* `head_title_page`: title of the page
+* `head_title`: override if you need more control over the `<title>` tag
+* `head_html5shim`: included by default, override if you don't want it
+* `head_viewport`: set to `device-width` with a scale of 1 by default, override if you hate mobile users
+* `head_meta`: where to put any other `<meta>` tags
+* `head_icons`: where to declare your favicons and Apple touch icons
+* `head_links`: where to put `<link>` tags, such as `rel=canonical`
+* `head_alternate`: where to put your Atom feeds
+* `head_css_stylesheet`: where to put the `<link>` to your stylesheet
+* `head_css_localstyles`: where to put page-specific CSS links or blocks
+* `head_css`: override if you need more control over styles
 
 ## Contact
 

--- a/django_cape/templates/cape/base.html
+++ b/django_cape/templates/cape/base.html
@@ -1,21 +1,21 @@
 {% extends 'cape/shell.html' %}
 
-{% block head-block %}
-  <title>{% block head-title %}{% block head-title-sitename %}SET WEBSITE NAME{% endblock %} — {% block head-title-page %}SET TITLE{% endblock %}{% endblock %}</title>
-  {% block head-html5shim %}
+{% block head_block %}
+  <title>{% block head_title %}{% block head_title_sitename %}SET WEBSITE NAME{% endblock %} — {% block head_title_page %}SET TITLE{% endblock %}{% endblock %}</title>
+  {% block head_html5shim %}
     <!--[if lt IE 9]>
     <script src='https://html5shim.googlecode.com/svn/trunk/html5.js'></script>
     <![endif]-->
   {% endblock %}
-  {% block head-viewport %}
+  {% block head_viewport %}
     <meta name='viewport' content='width=device-width, initial-scale=1'>
   {% endblock %}
-  {% block head-meta %}{% endblock %}
-  {% block head-icons %}{% endblock %}
-  {% block head-links %}{% endblock %}
-  {% block head-alternate %}{% endblock %}
-  {% block head-css %}
-    {% block head-css-stylesheet %}{% endblock %}
-    {% block head-css-localstyles %}{% endblock %}
+  {% block head_meta %}{% endblock %}
+  {% block head_icons %}{% endblock %}
+  {% block head_links %}{% endblock %}
+  {% block head_alternate %}{% endblock %}
+  {% block head_css %}
+    {% block head_css_stylesheet %}{% endblock %}
+    {% block head_css_localstyles %}{% endblock %}
   {% endblock %}
 {% endblock %}

--- a/django_cape/templates/cape/shell.html
+++ b/django_cape/templates/cape/shell.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang='{% block html-lang %}en-gb{% endblock %}' {% block html-attributes %}{% endblock %}>
-  <head {% block head-attributes %}{% endblock %}>
-    {% block head-charset %}
+<html lang='{% block html_lang %}en-gb{% endblock %}' {% block html_attributes %}{% endblock %}>
+  <head {% block head_attributes %}{% endblock %}>
+    {% block head_charset %}
       <meta charset='UTF-8'>
     {% endblock %}
-    {% block head-block %}{% endblock %}
+    {% block head_block %}{% endblock %}
     <script>
       window.CAPE = {};
       window.CAPE.stage = function(stage) {
@@ -13,20 +13,20 @@
       CAPE.timeout = setTimeout( CAPE.stage('timeout'), 5000 );
       CAPE.stage('capable');
     </script>
-    {% block javascript-head %}{% endblock %}
+    {% block javascript_head %}{% endblock %}
   </head>
-  <body {% block body-attributes %}{% endblock %} class='{% block body-class %}{% endblock %}'>
+  <body {% block body_attributes %}{% endblock %} class='{% block body_class %}{% endblock %}'>
     
-    {% block body-sheath %}{% endblock %}
+    {% block body_sheath %}{% endblock %}
     
-    {% block javascript-variables %}{% endblock %}
-    {% block javascript-libraries %}{% endblock %}
-    {% block javascript-enhance %}{% endblock %}
+    {% block javascript_variables %}{% endblock %}
+    {% block javascript_libraries %}{% endblock %}
+    {% block javascript_enhance %}{% endblock %}
     <script>
       clearTimeout(CAPE.timeout);
       CAPE.stage('ready');
     </script>
-    {% block javascript-asynchronous %}{% endblock %}
-    {% block javascript-analytics %}{% endblock %}
+    {% block javascript_asynchronous %}{% endblock %}
+    {% block javascript_analytics %}{% endblock %}
   </body>
 </html>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
     from distutils.core import setup
 
 PACKAGE = 'django_cape'
-VERSION = '0.1'
+VERSION = '1.0'
 
 package_data = {
         'django_cape': [ 'templates/cape/*.html' ],


### PR DESCRIPTION
In jinja, block names have to be valid python identifiers, which cannot
contain hyphens — so we change to using underscores.

As this is an incompatible change, increment the major version number.
